### PR TITLE
Add multiple API utilities and OpenAPI index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A set of simple serverless APIs hosted on Netlify.
 
 `encode-base64` takes a JSON input with a `name` field and returns the same object with an added `base64` field containing the Base64 (UTF-8) encoding of `name`.
 
-This project includes an automated `index.html` generator that lists all Functions (APIs). Run `npm run generate-index` or let Netlify build do it automatically.
+This project includes an automated `index.html` generator that outputs a simple OpenAPI specification listing all Functions (APIs). Run `npm run generate-index` or let Netlify build do it automatically.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ Response:
 
 ## Deployment
 
-Netlify will automatically generate and include an `index.html` listing all functions.
+Netlify will automatically generate and include an `index.html` containing an OpenAPI definition of all functions.
 
 1. Login to Netlify:
    ```bash

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Microservice Directory",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/.netlify/functions/decode-base64": {
+      "post": {
+        "description": "Reads a JSON payload with a \"base64\" field and returns the original payload"
+      }
+    },
+    "/.netlify/functions/decode-url": {
+      "post": {
+        "description": "Decodes a URL encoded string from the \"encoded\" field and returns it as \"decoded\"."
+      }
+    },
+    "/encode-base64": {
+      "post": {
+        "description": "A Netlify serverless function that reads a JSON payload with a \"name\" field"
+      }
+    },
+    "/.netlify/functions/encode-url": {
+      "post": {
+        "description": "URL encodes the provided \"text\" field and returns it as \"encoded\"."
+      }
+    },
+    "/.netlify/functions/generate-uuid": {
+      "post": {
+        "description": "Generates a random UUID v4 and returns it in a JSON response."
+      }
+    },
+    "/.netlify/functions/hash-md5": {
+      "post": {
+        "description": "Returns the MD5 hash of a given \"text\" field from the JSON payload."
+      }
+    }
+  }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,33 @@
   to = "/.netlify/functions/encode-base64"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/decode-base64"
+  to = "/.netlify/functions/decode-base64"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/hash-md5"
+  to = "/.netlify/functions/hash-md5"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/encode-url"
+  to = "/.netlify/functions/encode-url"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/decode-url"
+  to = "/.netlify/functions/decode-url"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/generate-uuid"
+  to = "/.netlify/functions/generate-uuid"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]

--- a/netlify/functions/decode-base64.js
+++ b/netlify/functions/decode-base64.js
@@ -1,0 +1,30 @@
+// netlify/functions/decode-base64.js
+/**
+ * Reads a JSON payload with a "base64" field and returns the original payload
+ * with an added "decoded" field containing the UTF-8 string represented by the
+ * Base64 value.
+ */
+exports.handler = async function(event, context) {
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const encoded = data.base64;
+    if (!encoded) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "base64" field in request body.' })
+      };
+    }
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    const response = { ...data, decoded };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/netlify/functions/decode-url.js
+++ b/netlify/functions/decode-url.js
@@ -1,0 +1,28 @@
+// netlify/functions/decode-url.js
+/**
+ * Decodes a URL encoded string from the "encoded" field and returns it as "decoded".
+ */
+exports.handler = async function(event, context) {
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const encoded = data.encoded;
+    if (!encoded) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "encoded" field in request body.' })
+      };
+    }
+    const decoded = decodeURIComponent(encoded);
+    const response = { ...data, decoded };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/netlify/functions/encode-url.js
+++ b/netlify/functions/encode-url.js
@@ -1,0 +1,28 @@
+// netlify/functions/encode-url.js
+/**
+ * URL encodes the provided "text" field and returns it as "encoded".
+ */
+exports.handler = async function(event, context) {
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const text = data.text;
+    if (!text) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "text" field in request body.' })
+      };
+    }
+    const encoded = encodeURIComponent(text);
+    const response = { ...data, encoded };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/netlify/functions/generate-uuid.js
+++ b/netlify/functions/generate-uuid.js
@@ -1,0 +1,14 @@
+// netlify/functions/generate-uuid.js
+/**
+ * Generates a random UUID v4 and returns it in a JSON response.
+ */
+const { randomUUID } = require('crypto');
+
+exports.handler = async function() {
+  const uuid = randomUUID();
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ uuid })
+  };
+};

--- a/netlify/functions/hash-md5.js
+++ b/netlify/functions/hash-md5.js
@@ -1,0 +1,30 @@
+// netlify/functions/hash-md5.js
+/**
+ * Returns the MD5 hash of a given "text" field from the JSON payload.
+ */
+const crypto = require('crypto');
+
+exports.handler = async function(event, context) {
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const text = data.text;
+    if (!text) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "text" field in request body.' })
+      };
+    }
+    const md5 = crypto.createHash('md5').update(text, 'utf8').digest('hex');
+    const response = { ...data, md5 };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -10,17 +10,16 @@ const indexPath = path.join(rootDir, 'index.html');
 // Read function files
 const files = fs.readdirSync(functionsDir).filter(f => f.endsWith('.js'));
 
-// Generate HTML
-let html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<title>Microservice Directory</title>
-</head>
-<body>
-<h1>API Index</h1>
-<ul>
-`;
+
+// Prepare basic OpenAPI structure
+const spec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Microservice Directory',
+    version: '1.0.0'
+  },
+  paths: {}
+};
 
 
  files.forEach(file => {
@@ -34,17 +33,16 @@ let html = `<!DOCTYPE html>
      desc = lines.find(line => line && !line.startsWith('@')) || '';
    }
    const name = path.basename(file, '.js');
-   // Map function name "encode-base64" to the friendly route "/encode-base64"
    const urlPath = name === 'encode-base64'
      ? '/encode-base64'
      : `/.netlify/functions/${name}`;
-   html += `  <li><strong>${urlPath}</strong>: ${desc}</li>\n`;
- });
+   spec.paths[urlPath] = {
+     post: {
+       description: desc
+     }
+   };
+});
 
-html += `</ul>
-</body>
-</html>`;
-
-// Write index.html
-fs.writeFileSync(indexPath, html);
-console.log('Generated index.html with', files.length, 'endpoints.');
+// Write index.html containing the OpenAPI JSON
+fs.writeFileSync(indexPath, JSON.stringify(spec, null, 2));
+console.log('Generated index.html with', files.length, 'endpoints in OpenAPI format.');


### PR DESCRIPTION
## Summary
- add convenience APIs (decode base64/url, encode url, md5 hash, uuid)
- generate `index.html` in OpenAPI format
- document OpenAPI index in README
- expose new endpoints in `netlify.toml`

## Testing
- `node scripts/generate-index.js`

------
https://chatgpt.com/codex/tasks/task_e_684d8d94ad0883209050854719778239