### PR TITLE
Align functions with swagger spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A set of simple serverless APIs hosted on Netlify.
 
-`encode-base64` takes a JSON input with a `name` field and returns the same object with an added `base64` field containing the Base64 (UTF-8) encoding of `name`.
+`/encode/base64` takes a JSON input with a `value` field and returns a response with an `encoded` field containing the Base64 (UTF-8) encoding of that value.
 
 This project uses a `swagger.json` file for all functions and loads Swagger UI from unpkg via `index.html`.
 
@@ -34,12 +34,12 @@ This project uses a `swagger.json` file for all functions and loads Swagger UI f
 
 Send a `POST` request with a JSON body:
 ```bash
-curl -X POST http://localhost:8888/encode-base64 \
+curl -X POST http://localhost:8888/encode/base64 \
   -H "Content-Type: application/json" \
-  -d '{"name":"test"}'
+  -d '{"value":"test"}'
 ```
 
 Response:
 ```json
-{"name":"test","base64":"dGVzdA=="}
+{"encoded":"dGVzdA=="}
 ```

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,37 +2,37 @@
   functions = "netlify/functions"
 
 [[redirects]]
-  from = "/encode-base64"
+  from = "/encode/base64"
   to = "/.netlify/functions/encode-base64"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
 
 [[redirects]]
-  from = "/decode-base64"
+  from = "/decode/base64"
   to = "/.netlify/functions/decode-base64"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
 
 [[redirects]]
-  from = "/hash-md5"
+  from = "/utilities/hash/md5"
   to = "/.netlify/functions/hash-md5"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
 
 [[redirects]]
-  from = "/encode-url"
+  from = "/encode/url"
   to = "/.netlify/functions/encode-url"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
 
 [[redirects]]
-  from = "/decode-url"
+  from = "/decode/url"
   to = "/.netlify/functions/decode-url"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
 
 [[redirects]]
-  from = "/generate-uuid"
+  from = "/utilities/uuid"
   to = "/.netlify/functions/generate-uuid"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]

--- a/netlify/functions/decode-base64.js
+++ b/netlify/functions/decode-base64.js
@@ -1,21 +1,20 @@
 // netlify/functions/decode-base64.js
 /**
- * Reads a JSON payload with a "base64" field and returns the original payload
- * with an added "decoded" field containing the UTF-8 string represented by the
- * Base64 value.
+ * Reads a JSON payload with a "value" field containing a Base64 string and
+ * returns a JSON object with a "decoded" field containing the UTF-8 value.
  */
 exports.handler = async function(event, context) {
   try {
     const data = JSON.parse(event.body || '{}');
-    const encoded = data.base64;
+    const encoded = data.value;
     if (!encoded) {
       return {
         statusCode: 400,
-        body: JSON.stringify({ error: 'Missing "base64" field in request body.' })
+        body: JSON.stringify({ error: 'Missing "value" field in request body.' })
       };
     }
     const decoded = Buffer.from(encoded, 'base64').toString('utf8');
-    const response = { ...data, decoded };
+    const response = { decoded };
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/netlify/functions/decode-url.js
+++ b/netlify/functions/decode-url.js
@@ -13,7 +13,7 @@ exports.handler = async function(event, context) {
       };
     }
     const decoded = decodeURIComponent(encoded);
-    const response = { ...data, decoded };
+    const response = { decoded };
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/netlify/functions/encode-base64.js
+++ b/netlify/functions/encode-base64.js
@@ -1,22 +1,22 @@
 // netlify/functions/encode-base64.js
 
 /**
- * A Netlify serverless function that reads a JSON payload with a "name" field
- * and returns the original payload with an added "base64" field containing the
- * Base64 (UTF-8) encoding of the "name" value.
+ * A Netlify serverless function that reads a JSON payload with a "value" field
+ * and returns a JSON object with an "encoded" field containing the Base64
+ * (UTF-8) encoding of that value.
  */
 exports.handler = async function(event, context) {
   try {
     const data = JSON.parse(event.body || '{}');
-    const name = data.name;
-    if (!name) {
+    const value = data.value;
+    if (!value) {
       return {
         statusCode: 400,
-        body: JSON.stringify({ error: 'Missing "name" field in request body.' }),
+        body: JSON.stringify({ error: 'Missing "value" field in request body.' }),
       };
     }
-    const base64 = Buffer.from(name, 'utf8').toString('base64');
-    const response = { ...data, base64 };
+    const encoded = Buffer.from(value, 'utf8').toString('base64');
+    const response = { encoded };
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/netlify/functions/encode-url.js
+++ b/netlify/functions/encode-url.js
@@ -13,7 +13,7 @@ exports.handler = async function(event, context) {
       };
     }
     const encoded = encodeURIComponent(text);
-    const response = { ...data, encoded };
+    const response = { encoded };
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/netlify/functions/hash-md5.js
+++ b/netlify/functions/hash-md5.js
@@ -14,8 +14,8 @@ exports.handler = async function(event, context) {
         body: JSON.stringify({ error: 'Missing "text" field in request body.' })
       };
     }
-    const md5 = crypto.createHash('md5').update(text, 'utf8').digest('hex');
-    const response = { ...data, md5 };
+    const hash = crypto.createHash('md5').update(text, 'utf8').digest('hex');
+    const response = { hash };
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- fix endpoint URLs and field names in README example
- sync serverless functions with `swagger.json`
- update redirects to use `/encode/` and `/decode/` paths

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6860c9ae19ac8320a0f709b61cbb5732