### PR TITLE
Introduce serverless rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration
+# Limit requests per second. Comment out or set to 0 to disable.
+RATE_LIMIT_RPS=5

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ This project uses a `swagger.json` file for all functions and loads Swagger UI f
    npm install
    ```
 
-3. Run locally:
+3. (Optional) Create a `.env` file with a `RATE_LIMIT_RPS` value to limit
+   requests per second. Example:
+   ```bash
+   echo "RATE_LIMIT_RPS=5" > .env
+   ```
+
+4. Run locally:
    ```bash
    netlify dev
    ```
@@ -43,3 +49,9 @@ Response:
 ```json
 {"encoded":"dGVzdA=="}
 ```
+
+## Rate Limiting
+
+If `RATE_LIMIT_RPS` is set in the `.env` file, all functions enforce the
+specified number of requests per second. When the limit is exceeded, functions
+return HTTP `429` with `{ "error": "Too many requests" }`.

--- a/netlify/functions/decode-base64.js
+++ b/netlify/functions/decode-base64.js
@@ -3,7 +3,16 @@
  * Reads a JSON payload with a "value" field containing a Base64 string and
  * returns a JSON object with a "decoded" field containing the UTF-8 value.
  */
+const checkRateLimit = require('./rate-limit');
+
 exports.handler = async function(event, context) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
   try {
     const data = JSON.parse(event.body || '{}');
     const encoded = data.value;

--- a/netlify/functions/decode-url.js
+++ b/netlify/functions/decode-url.js
@@ -2,7 +2,16 @@
 /**
  * Decodes a URL encoded string from the "encoded" field and returns it as "decoded".
  */
+const checkRateLimit = require('./rate-limit');
+
 exports.handler = async function(event, context) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
   try {
     const data = JSON.parse(event.body || '{}');
     const encoded = data.encoded;

--- a/netlify/functions/encode-base64.js
+++ b/netlify/functions/encode-base64.js
@@ -5,7 +5,16 @@
  * and returns a JSON object with an "encoded" field containing the Base64
  * (UTF-8) encoding of that value.
  */
+const checkRateLimit = require('./rate-limit');
+
 exports.handler = async function(event, context) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' }),
+    };
+  }
   try {
     const data = JSON.parse(event.body || '{}');
     const value = data.value;

--- a/netlify/functions/encode-url.js
+++ b/netlify/functions/encode-url.js
@@ -2,7 +2,16 @@
 /**
  * URL encodes the provided "text" field and returns it as "encoded".
  */
+const checkRateLimit = require('./rate-limit');
+
 exports.handler = async function(event, context) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
   try {
     const data = JSON.parse(event.body || '{}');
     const text = data.text;

--- a/netlify/functions/generate-uuid.js
+++ b/netlify/functions/generate-uuid.js
@@ -4,7 +4,16 @@
  */
 const { randomUUID } = require('crypto');
 
+const checkRateLimit = require('./rate-limit');
+
 exports.handler = async function() {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
   const uuid = randomUUID();
   return {
     statusCode: 200,

--- a/netlify/functions/hash-md5.js
+++ b/netlify/functions/hash-md5.js
@@ -3,8 +3,16 @@
  * Returns the MD5 hash of a given "text" field from the JSON payload.
  */
 const crypto = require('crypto');
+const checkRateLimit = require('./rate-limit');
 
 exports.handler = async function(event, context) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
   try {
     const data = JSON.parse(event.body || '{}');
     const text = data.text;

--- a/netlify/functions/rate-limit.js
+++ b/netlify/functions/rate-limit.js
@@ -1,0 +1,18 @@
+let requestCount = 0;
+let lastReset = Date.now();
+const limit = parseInt(process.env.RATE_LIMIT_RPS, 10);
+
+function checkRateLimit() {
+  if (!limit || Number.isNaN(limit)) {
+    return true;
+  }
+  const now = Date.now();
+  if (now - lastReset >= 1000) {
+    requestCount = 0;
+    lastReset = now;
+  }
+  requestCount += 1;
+  return requestCount <= limit;
+}
+
+module.exports = checkRateLimit;

--- a/swagger.json
+++ b/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "Small free APIs for anyone to use, hosted on Netlify.",
+    "description": "Small free APIs for anyone to use, hosted on Netlify. Requests may be rate limited using the RATE_LIMIT_RPS environment variable.",
     "title": "Microservice Directory",
     "version": "1.0.0"
   },


### PR DESCRIPTION
## Summary
- add a shared rate-limit utility for Netlify functions
- enforce rate limits in all functions
- document environment variable configuration
- describe rate limiting in swagger.json
- provide `.env.example` for quick setup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68614bc2d260832093d5e96d68bdeb36