### PR TITLE
Add hex encode/decode and new utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A set of simple serverless APIs hosted on Netlify.
 
 `/encode/base64` takes a JSON input with a `value` field and returns a response with an `encoded` field containing the Base64 (UTF-8) encoding of that value.
+Additional endpoints cover Base64 decoding, URL encoding/decoding, hex encoding/decoding, hashing, UUID generation and timestamps.
 
 This project uses a `swagger.json` file for all functions and loads Swagger UI from unpkg via `index.html`.
 

--- a/index.html
+++ b/index.html
@@ -22,5 +22,6 @@
       });
     };
   </script>
+<style>#forkongithub a{background:#000;color:#fff;text-decoration:none;font-family:arial,sans-serif;text-align:center;font-weight:bold;padding:5px 40px;font-size:1rem;line-height:2rem;position:relative;transition:0.5s;}#forkongithub a:hover{background:#c11;color:#fff;}#forkongithub a::before,#forkongithub a::after{content:"";width:100%;display:block;position:absolute;top:1px;left:0;height:1px;background:#fff;}#forkongithub a::after{bottom:1px;top:auto;}@media screen and (min-width:800px){#forkongithub{position:fixed;display:block;top:0;right:0;width:200px;overflow:hidden;height:200px;z-index:9999;}#forkongithub a{width:200px;position:absolute;top:60px;right:-60px;transform:rotate(45deg);-webkit-transform:rotate(45deg);-ms-transform:rotate(45deg);-moz-transform:rotate(45deg);-o-transform:rotate(45deg);box-shadow:4px 4px 10px rgba(0,0,0,0.8);}}</style><span id="forkongithub"><a href="https://github.com/patricktobias86/microservice-directory">Find me on GitHub</a></span>
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -36,3 +36,27 @@
   to = "/.netlify/functions/generate-uuid"
   status = 200
   methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/encode/hex"
+  to = "/.netlify/functions/encode-hex"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/decode/hex"
+  to = "/.netlify/functions/decode-hex"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/utilities/hash/sha256"
+  to = "/.netlify/functions/hash-sha256"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]
+
+[[redirects]]
+  from = "/utilities/timestamp"
+  to = "/.netlify/functions/timestamp"
+  status = 200
+  methods = ["GET", "POST", "OPTIONS"]

--- a/netlify/functions/decode-hex.js
+++ b/netlify/functions/decode-hex.js
@@ -1,0 +1,37 @@
+// netlify/functions/decode-hex.js
+/**
+ * Decodes a hex string provided in the "value" field and returns it as "decoded".
+ */
+const checkRateLimit = require('./rate-limit');
+
+exports.handler = async function(event) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const value = data.value;
+    if (!value) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "value" field in request body.' })
+      };
+    }
+    const decoded = Buffer.from(value, 'hex').toString('utf8');
+    const response = { decoded };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/netlify/functions/encode-hex.js
+++ b/netlify/functions/encode-hex.js
@@ -1,0 +1,37 @@
+// netlify/functions/encode-hex.js
+/**
+ * Converts the provided "value" field to a hex string and returns it as "encoded".
+ */
+const checkRateLimit = require('./rate-limit');
+
+exports.handler = async function(event) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const value = data.value;
+    if (!value) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "value" field in request body.' })
+      };
+    }
+    const encoded = Buffer.from(value, 'utf8').toString('hex');
+    const response = { encoded };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/netlify/functions/hash-sha256.js
+++ b/netlify/functions/hash-sha256.js
@@ -1,0 +1,38 @@
+// netlify/functions/hash-sha256.js
+/**
+ * Returns the SHA-256 hash of a given "text" field from the JSON payload.
+ */
+const crypto = require('crypto');
+const checkRateLimit = require('./rate-limit');
+
+exports.handler = async function(event) {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
+  try {
+    const data = JSON.parse(event.body || '{}');
+    const text = data.text;
+    if (!text) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing "text" field in request body.' })
+      };
+    }
+    const hash = crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+    const response = { hash };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid JSON in request body.' })
+    };
+  }
+};

--- a/netlify/functions/timestamp.js
+++ b/netlify/functions/timestamp.js
@@ -1,0 +1,21 @@
+// netlify/functions/timestamp.js
+/**
+ * Returns the current timestamp in ISO 8601 format.
+ */
+const checkRateLimit = require('./rate-limit');
+
+exports.handler = async function() {
+  if (!checkRateLimit()) {
+    return {
+      statusCode: 429,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too many requests' })
+    };
+  }
+  const timestamp = new Date().toISOString();
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ timestamp })
+  };
+};

--- a/swagger.json
+++ b/swagger.json
@@ -111,6 +111,56 @@
         "summary": "URL-decode the provided string"
       }
     },
+    "/decode/hex": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HexDecodeRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Decoded string",
+            "examples": {
+              "application/json": {
+                "decoded": "test"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/HexDecodeResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "decode"
+        ],
+        "operationId": "decodeHex",
+        "summary": "Decode a hex string"
+      }
+    },
     "/encode/base64": {
       "post": {
         "consumes": [
@@ -211,6 +261,56 @@
         "summary": "URL-encode the provided text"
       }
     },
+    "/encode/hex": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HexEncodeRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hex encoded string",
+            "examples": {
+              "application/json": {
+                "encoded": "74657374"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/HexEncodeResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "encode"
+        ],
+        "operationId": "encodeHex",
+        "summary": "Encode a string to hex"
+      }
+    },
     "/utilities/hash/md5": {
       "post": {
         "consumes": [
@@ -261,6 +361,56 @@
         "summary": "Compute MD5 hash of a text string"
       }
     },
+    "/utilities/hash/sha256": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Sha256HashRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SHA-256 hash of the input",
+            "examples": {
+              "application/json": {
+                "hash": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Sha256HashResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "utilities"
+        ],
+        "operationId": "hashSha256",
+        "summary": "Compute SHA-256 hash of a text string"
+      }
+    },
     "/utilities/uuid": {
       "get": {
         "produces": [
@@ -285,6 +435,32 @@
         ],
         "operationId": "generateUuid",
         "summary": "Generate a random UUID v4"
+      }
+    },
+    "/utilities/timestamp": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current timestamp",
+            "examples": {
+              "application/json": {
+                "timestamp": "2023-01-01T00:00:00.000Z"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/TimestampResponse"
+            }
+          }
+        },
+        "tags": [
+          "utilities"
+        ],
+        "operationId": "getTimestamp",
+        "summary": "Return the current timestamp in ISO format"
       }
     }
   },
@@ -436,6 +612,90 @@
       },
       "required": [
         "uuid"
+      ],
+      "type": "object"
+    },
+    "HexEncodeRequest": {
+      "properties": {
+        "value": {
+          "example": "test",
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "HexEncodeResponse": {
+      "properties": {
+        "encoded": {
+          "example": "74657374",
+          "type": "string"
+        }
+      },
+      "required": [
+        "encoded"
+      ],
+      "type": "object"
+    },
+    "HexDecodeRequest": {
+      "properties": {
+        "value": {
+          "example": "74657374",
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "HexDecodeResponse": {
+      "properties": {
+        "decoded": {
+          "example": "test",
+          "type": "string"
+        }
+      },
+      "required": [
+        "decoded"
+      ],
+      "type": "object"
+    },
+    "Sha256HashRequest": {
+      "properties": {
+        "text": {
+          "example": "hello",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    },
+    "Sha256HashResponse": {
+      "properties": {
+        "hash": {
+          "example": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hash"
+      ],
+      "type": "object"
+    },
+    "TimestampResponse": {
+      "properties": {
+        "timestamp": {
+          "example": "2023-01-01T00:00:00.000Z",
+          "type": "string"
+        }
+      },
+      "required": [
+        "timestamp"
       ],
       "type": "object"
     }


### PR DESCRIPTION
## Summary
- add new hex encoder/decoder functions
- add SHA-256 hash and timestamp utilities
- wire up new routes in `netlify.toml`
- document new endpoints in README
- extend OpenAPI specification

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68626e57dad48320890615174df80a1c