### PR TITLE
Add timezone support to timestamp API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A set of simple serverless APIs hosted on Netlify.
 
 `/encode/base64` takes a JSON input with a `value` field and returns a response with an `encoded` field containing the Base64 (UTF-8) encoding of that value.
-Additional endpoints cover Base64 decoding, URL encoding/decoding, hex encoding/decoding, hashing, UUID generation and timestamps. A `/usage` endpoint returns anonymous counts for each API.
+Additional endpoints cover Base64 decoding, URL encoding/decoding, hex encoding/decoding, hashing, UUID generation and timestamps. A `/usage` endpoint returns anonymous counts for each API. The timestamp endpoint returns both ISO and UNIX formats and accepts an optional `timezone` query parameter using IANA names (for example, `timezone=America/New_York`).
 
 This project uses a `swagger.json` file for all functions and loads Swagger UI from unpkg via `index.html`.
 

--- a/netlify/functions/timestamp.js
+++ b/netlify/functions/timestamp.js
@@ -1,11 +1,35 @@
 // netlify/functions/timestamp.js
 /**
- * Returns the current timestamp in ISO 8601 format.
+ * Returns the current timestamp in ISO 8601 and UNIX format.
+ * Accepts an optional `timezone` query parameter using IANA names
+ * like "America/New_York". Defaults to UTC.
  */
 const checkRateLimit = require('./rate-limit');
 const { record } = require('./usage');
 
-exports.handler = async function() {
+function formatIso(date, zone) {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  });
+  const parts = fmt.formatToParts(date);
+  const get = type => parts.find(p => p.type === type).value;
+  const base = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`;
+  const tzDate = new Date(date.toLocaleString('en-US', { timeZone: zone }));
+  const diff = Math.round((tzDate.getTime() - date.getTime()) / 60000);
+  const sign = diff > 0 ? '+' : diff < 0 ? '-' : '+';
+  const abs = Math.abs(diff);
+  const offset = `${sign}${String(Math.floor(abs / 60)).padStart(2, '0')}:${String(abs % 60).padStart(2, '0')}`;
+  return base + offset;
+}
+
+exports.handler = async function(event) {
   if (!checkRateLimit()) {
     return {
       statusCode: 429,
@@ -14,10 +38,22 @@ exports.handler = async function() {
     };
   }
   record('timestamp');
-  const timestamp = new Date().toISOString();
+  const zone = (event && event.queryStringParameters && event.queryStringParameters.timezone) || 'UTC';
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: zone });
+  } catch {
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Invalid timezone' })
+    };
+  }
+  const now = new Date();
+  const iso = formatIso(now, zone);
+  const unix = Math.floor(now.getTime() / 1000);
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ timestamp })
+    body: JSON.stringify({ iso, unix })
   };
 };

--- a/swagger.json
+++ b/swagger.json
@@ -442,17 +442,32 @@
         "produces": [
           "application/json"
         ],
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "IANA time zone name. Defaults to UTC."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Current timestamp",
             "examples": {
               "application/json": {
-                "timestamp": "2023-01-01T00:00:00.000Z"
+                "iso": "2023-01-01T00:00:00+00:00",
+                "unix": 1672531200
               }
             },
             "schema": {
               "$ref": "#/definitions/TimestampResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid timezone",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
             }
           }
         },
@@ -460,7 +475,7 @@
           "utilities"
         ],
         "operationId": "getTimestamp",
-        "summary": "Return the current timestamp in ISO format"
+        "summary": "Return the current timestamp in ISO and UNIX format",
       }
     },
     "/usage": {
@@ -719,13 +734,18 @@
     },
     "TimestampResponse": {
       "properties": {
-        "timestamp": {
-          "example": "2023-01-01T00:00:00.000Z",
+        "iso": {
+          "example": "2023-01-01T00:00:00+00:00",
           "type": "string"
+        },
+        "unix": {
+          "example": 1672531200,
+          "type": "integer"
         }
       },
       "required": [
-        "timestamp"
+        "iso",
+        "unix"
       ],
       "type": "object"
     }

--- a/tests/functions.test.js
+++ b/tests/functions.test.js
@@ -7,6 +7,7 @@ const encodeUrl = require('../netlify/functions/encode-url.js');
 const decodeUrl = require('../netlify/functions/decode-url.js');
 const hashMd5 = require('../netlify/functions/hash-md5.js');
 const generateUuid = require('../netlify/functions/generate-uuid.js');
+const timestamp = require('../netlify/functions/timestamp.js');
 const stats = require('../netlify/functions/stats.js');
 
 // Test encodeBase64
@@ -61,6 +62,22 @@ test('generateUuid returns a uuid v4', async () => {
   assert.strictEqual(res.statusCode, 200);
   const body = JSON.parse(res.body);
   assert.match(body.uuid, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+});
+
+// Test timestamp
+test('timestamp returns iso and unix for timezone', async () => {
+  const event = { queryStringParameters: { timezone: 'UTC' } };
+  const res = await timestamp.handler(event);
+  assert.strictEqual(res.statusCode, 200);
+  const body = JSON.parse(res.body);
+  assert.ok(body.iso.endsWith('+00:00'));
+  assert.ok(Number.isInteger(body.unix));
+});
+
+test('timestamp rejects invalid timezone', async () => {
+  const event = { queryStringParameters: { timezone: 'Invalid/Zone' } };
+  const res = await timestamp.handler(event);
+  assert.strictEqual(res.statusCode, 400);
 });
 
 // Test usage stats


### PR DESCRIPTION
## Summary
- allow timezone query param and return ISO and UNIX time
- document timestamp query param and response
- test timestamp handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868eb2d6088832081b93170c5496a60