### PR TITLE
Fix swagger.json validity and add validator test

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -475,8 +475,8 @@
           "utilities"
         ],
         "operationId": "getTimestamp",
-        "summary": "Return the current timestamp in ISO and UNIX format",
-      }
+        "summary": "Return the current timestamp in ISO and UNIX format"
+    }
     },
     "/usage": {
       "get": {

--- a/tests/functions.test.js
+++ b/tests/functions.test.js
@@ -9,6 +9,7 @@ const hashMd5 = require('../netlify/functions/hash-md5.js');
 const generateUuid = require('../netlify/functions/generate-uuid.js');
 const timestamp = require('../netlify/functions/timestamp.js');
 const stats = require('../netlify/functions/stats.js');
+const fs = require('fs');
 
 // Test encodeBase64
 test('encodeBase64 encodes text to base64', async () => {
@@ -87,4 +88,17 @@ test('stats endpoint returns usage counts', async () => {
   assert.strictEqual(res.statusCode, 200);
   const body = JSON.parse(res.body);
   assert.ok(body.encodeBase64 >= 1);
+});
+
+// Validate swagger.json with online Swagger validator
+test('swagger.json is valid', async () => {
+  const schema = fs.readFileSync('./swagger.json', 'utf8');
+  const res = await fetch('https://validator.swagger.io/validator/debug', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: schema
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.deepStrictEqual(body, { schemaValidationMessages: [] });
 });


### PR DESCRIPTION
## Summary
- fix trailing comma and missing braces in `swagger.json`
- add `swagger.json` validation test

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6868f5038294832088cafb62297be053